### PR TITLE
Add support for systemd

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -11,6 +11,9 @@ platforms:
     require_chef_omnibus: true
     box: debian-7.2.0
     box_url: https://dl.dropboxusercontent.com/u/197673519/debian-7.2.0.box
+- name: Debian8
+  driver:
+    box: debian/jessie64
 
 suites:
 - name: default
@@ -18,5 +21,6 @@ suites:
     - recipe[monit_bin::default]
   attributes:
     monit:
+      version: 5.9
       monitrc:
         http_address: 127.0.0.1

--- a/files/default/monit_default_sysvinit
+++ b/files/default/monit_default_sysvinit
@@ -1,0 +1,10 @@
+# /etc/default/monit
+
+# Defaults for monit initscript.  This file is sourced by
+# /bin/sh from /etc/init.d/monit.
+
+# You must set this variable to yes for monit to start
+START=yes
+
+# Options to pass to monit
+MONIT_OPTS=

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email "sawanoboriyu@higanworks.com"
 license          "MIT"
 description      "Installs/Configures monit_bin"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "1.1.3"
+version          "1.1.4"
 supports         "ubuntu"
 supports         "smartos"
 supports         "debian"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -34,8 +34,16 @@ else
     mode 0755
   end
 
-  cookbook_file "/etc/default/monit" do
-    source "monit_default"
+  if node[:init_package] == "systemd" then
+    cookbook_file "/etc/default/monit" do
+      source "monit_default_sysvinit"
+      notifies :restart, "service[monit]"
+    end
+  else
+    cookbook_file "/etc/default/monit" do
+      source "monit_default"
+      notifies :restart, "service[monit]"
+    end
   end
 end
 


### PR DESCRIPTION
 - Removing option `-I` via /etc/default/monit so it works with systemctl